### PR TITLE
Use portals to fix bounds issues with tethered content

### DIFF
--- a/src/TetherContent/index.js
+++ b/src/TetherContent/index.js
@@ -37,6 +37,12 @@ class TetherContent extends React.Component {// eslint-disable-line react/prefer
 
   static defaultProps = defaultProps;
 
+  constructor(props) {
+    super(props);
+
+    this.element = document.createElement('div');
+  }
+
   componentDidMount = () => {
     this.handleProps();
   }
@@ -44,9 +50,6 @@ class TetherContent extends React.Component {// eslint-disable-line react/prefer
   componentDidUpdate = (prevProps) => {
     if (this.props.isOpen !== prevProps.isOpen) {
       this.handleProps();
-    } else if (this.element) {
-      // rerender
-      this.renderIntoSubtree();
     }
   }
 
@@ -92,10 +95,8 @@ class TetherContent extends React.Component {// eslint-disable-line react/prefer
   hide = () => {
     document.removeEventListener('click', this.handleDocumentClick, true);
 
-    if (this.element) {
+    if (this.element.parentElement === document.body) {
       document.body.removeChild(this.element);
-      ReactDOM.unmountComponentAtNode(this.element);
-      this.element = null;
     }
 
     if (this.tether) {
@@ -110,10 +111,8 @@ class TetherContent extends React.Component {// eslint-disable-line react/prefer
   show = () => {
     document.addEventListener('click', this.handleDocumentClick, true);
 
-    this.element = document.createElement('div');
     this.element.className = this.props.className;
     document.body.appendChild(this.element);
-    this.renderIntoSubtree();
     this.tether = new Tether(this.getTetherConfig());
     if (this.props.tetherRef) {
       this.props.tetherRef(this.tether);
@@ -129,14 +128,6 @@ class TetherContent extends React.Component {// eslint-disable-line react/prefer
     return this.props.toggle();
   }
 
-  renderIntoSubtree = () => {
-    ReactDOM.unstable_renderSubtreeIntoContainer(
-      this,
-      this.renderChildren(),
-      this.element
-    );
-  }
-
   renderChildren = () => {
     const { children, style } = this.props;
     return React.cloneElement(
@@ -146,8 +137,13 @@ class TetherContent extends React.Component {// eslint-disable-line react/prefer
   }
 
   render() {
-    return (
-      null
+    if (!this.props.isOpen) {
+      return null;
+    }
+
+    return ReactDOM.createPortal(
+      this.renderChildren(),
+      this.element
     );
   }
 }


### PR DESCRIPTION
This is an attempted fix of #69. 

The current method of rendering children of `TetherContent` causes tether to compute position based off the size of an empty div, causing the alignment issues documented in the linked issue. I've updated the code to use portals instead of the unsafe render method, and rearranged some of the logic in the lifecycle methods to account for the difference in how portals are used. Now the tethered element has the React content before tether is called to do position ing. This appears to have fixed the issue.

Previous `placement="right"`:
<img width="353" alt="Screen Shot 2019-03-10 at 12 59 41 AM" src="https://user-images.githubusercontent.com/4017830/54082993-c0663580-42d2-11e9-8c50-a80670fb901e.png">
New `placement="right"`:
<img width="345" alt="Screen Shot 2019-03-10 at 12 35 00 AM" src="https://user-images.githubusercontent.com/4017830/54082999-cb20ca80-42d2-11e9-842b-1cf058b0e51b.png">
Previous `placement="top"`:
<img width="336" alt="Screen Shot 2019-03-10 at 1 19 22 AM" src="https://user-images.githubusercontent.com/4017830/54083006-decc3100-42d2-11e9-8372-03c95d6df5ce.png">
New `placement="top"`:
<img width="288" alt="Screen Shot 2019-03-10 at 1 19 45 AM" src="https://user-images.githubusercontent.com/4017830/54083009-e7246c00-42d2-11e9-9550-5c08c42cf3ce.png">