### PR TITLE
fix(Select component): fixed Select component for SSR

### DIFF
--- a/src/Select/index.js
+++ b/src/Select/index.js
@@ -23,16 +23,18 @@ class SelectUnstyled extends React.Component { // eslint-disable-line react/pref
 
   // Android browser fix: https://v4-alpha.getbootstrap.com/getting-started/browsers-devices/#android-stock-browser
   componentWillMount() {
-    const nua = navigator.userAgent;
-    const isAndroid = (nua.indexOf('Mozilla/5.0') > -1 && nua.indexOf('Android ') > -1 && nua.indexOf('AppleWebKit') > -1 && nua.indexOf('Chrome') === -1);
-    if (isAndroid) {
-      this.setState({
-        className: this.props.className.replace(/\bform-control\b/, ''),
-      });
-    } else {
-      this.setState({
-        className: this.props.className,
-      });
+    if (typeof window !== 'undefined') {
+      const nua = navigator.userAgent;
+      const isAndroid = (nua.indexOf('Mozilla/5.0') > -1 && nua.indexOf('Android ') > -1 && nua.indexOf('AppleWebKit') > -1 && nua.indexOf('Chrome') === -1);
+      if (isAndroid) {
+        this.setState({
+          className: this.props.className.replace(/\bform-control\b/, ''),
+        });
+      } else {
+        this.setState({
+          className: this.props.className,
+        });
+      }
     }
   }
 


### PR DESCRIPTION
The Select component is invoking window.navigator in componentWillUpdate. This seems like an
antipattern in general. I added a hotfix to only apply this Android hotfix if this component is ran
on the browser.

fix #121

## v4
