### PR TITLE
fix(Tooltip): Use the $tooltip-arrow-color variable within the compon…

### DIFF
--- a/src/Tooltip/index.js
+++ b/src/Tooltip/index.js
@@ -324,7 +324,7 @@ const Tooltip = styled(TooltipUnstyled)`
       margin-left: -5px;
       content: "";
       border-width: 5px 5px 0;
-      border-top-color: #000
+      border-top-color: ${props.theme['$tooltip-arrow-color']};
     }
     
     &.tooltip.bs-tether-element-attached-left,
@@ -340,7 +340,7 @@ const Tooltip = styled(TooltipUnstyled)`
       margin-top: -5px;
       content: "";
       border-width: 5px 5px 5px 0;
-      border-right-color: #000
+      border-right-color: ${props.theme['$tooltip-arrow-color']};
     }
     
     &.tooltip.bs-tether-element-attached-top,
@@ -356,7 +356,7 @@ const Tooltip = styled(TooltipUnstyled)`
       margin-left: -5px;
       content: "";
       border-width: 0 5px 5px;
-      border-bottom-color: #000
+      border-bottom-color: ${props.theme['$tooltip-arrow-color']};
     }
     
     &.tooltip.bs-tether-element-attached-right,
@@ -372,7 +372,7 @@ const Tooltip = styled(TooltipUnstyled)`
       margin-top: -5px;
       content: "";
       border-width: 5px 0 5px 5px;
-      border-left-color: #000
+      border-left-color: ${props.theme['$tooltip-arrow-color']};
     }
     
     & .tooltip-inner {


### PR DESCRIPTION
…ent style

Used existing variable for $tooltip-arrow-color that was not referenced in the styling of the tooltip component.

## v4

Thank you for contributing! Please take a moment to review our [**contributing guidelines**](https://github.com/bootstrap-styled/v4/blob/master/CONTRIBUTING.md)
to make the process easy and effective for everyone involved.

**Please open an issue** before embarking on any significant pull request, especially those that
add a new library or change existing tests, otherwise you risk spending a lot of time working
on something that might not end up being merged into the project.

Before opening a pull request, please ensure:

- [x] You have followed our [**contributing guidelines**](https://github.com/bootstrap-styled/v4/blob/master/.github/CONTRIBUTING.md)
- [x] Double-check your branch is based on `dev` and targets `dev`
- [x] Your are doing semantic commit message using [commitizen](https://github.com/commitizen/cz-cli) and our [commit message convention](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines)
- [ ] Pull request has tests (we are going for 100% coverage!)
- [x] Code is well-commented, linted and follows project conventions
- [x] Documentation is updated (if necessary)
- [x] Description explains the issue/use-case resolved and auto-closes related issues

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)

**IMPORTANT**: By submitting a patch, you agree to allow the project
owners to license your work under the terms of the [ License](https://github.com/bootstrap-styled/v4/blob/master/LICENSE.md).
