### PR TITLE
feat(button): add props.color option 'white'

### DIFF
--- a/src/Button/index.js
+++ b/src/Button/index.js
@@ -81,6 +81,7 @@ export const propTypes = {
     'info',
     'warning',
     'danger',
+    'white',
   ]),
   /** Use that property to pass a ref callback to the native button component. */
   ref: PropTypes.func,
@@ -264,7 +265,7 @@ const Button = styled(ButtonUnstyled)`
     props.theme['$btn-danger-border'],
     props.theme['$btn-disabled-opacity'],
   )}
- `} 
+ `}
 `;
 
 Button.defaultProps = defaultProps;


### PR DESCRIPTION
Add the option to pass 'white' as props.color value to an instance
of the Button component. Previously, console would log propType
error as Button.propTypes.color did not allow for 'white' as an
option. This change will allow 'white', and prevent the error.

this commit closes #178

## v4

Thank you for contributing! Please take a moment to review our [**contributing guidelines**](https://github.com/bootstrap-styled/v4/blob/master/CONTRIBUTING.md)
to make the process easy and effective for everyone involved.

**Please open an issue** before embarking on any significant pull request, especially those that
add a new library or change existing tests, otherwise you risk spending a lot of time working
on something that might not end up being merged into the project.

Before opening a pull request, please ensure:

- [ ] You have followed our [**contributing guidelines**](https://github.com/bootstrap-styled/v4/blob/master/.github/CONTRIBUTING.md)
- [ ] Double-check your branch is based on `dev` and targets `dev`
- [ ] Your are doing semantic commit message using ~[commitizen](https://github.com/commitizen/cz-cli) and~ our [commit message convention](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines)
- [ ] Pull request has tests (we are going for 100% coverage!)
- [ ] Code is well-commented, linted and follows project conventions
- [ ] Documentation is updated (if necessary)
- [ ] Description explains the issue/use-case resolved and auto-closes related issues

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)

**IMPORTANT**: By submitting a patch, you agree to allow the project
owners to license your work under the terms of the [License](https://github.com/bootstrap-styled/v4/blob/master/LICENSE.md).
